### PR TITLE
Correctly hooks up the port ENV in run.py

### DIFF
--- a/{{cookiecutter.repo_name}}/run.py
+++ b/{{cookiecutter.repo_name}}/run.py
@@ -5,4 +5,4 @@ from {{cookiecutter.repo_name}} import main
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 5000))
-    main.app.run()
+    main.app.run(port=port)


### PR DESCRIPTION
Looks like this was a simple oversight :)
