### PR TITLE
Use expected config object when creating app instance

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/app.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/app.py
@@ -18,8 +18,7 @@ def create_app(config_object, env):
     :param env: A string, the current environment. Either "dev" or "prod"
     '''
     app = Flask(__name__)
-    app.config.from_object('{{cookiecutter.repo_name}}.settings.{env}Config'
-                            .format(env=env.capitalize()))
+    app.config.from_object(config_object)
     app.config['ENV'] = env
     # Initialize SQLAlchemy
     db.init_app(app)


### PR DESCRIPTION
### Purpose

Properly use the `config_object` parameter inside of `create_app`.
### Description

Since we determine config object in all entry points, we should properly use the object within the creation function instead of rebuilding this object path.  The noted entry points are located:
- `{{cookiecutter.repo_name}}/manage.py`
- `{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/app.py`
- `{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/main.py`
- `{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/tests/unit_tests.py`
