### PR TITLE
reflect Bootstrap's org change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ You will be asked about your basic info (name, project name, app name, etc.). Th
 Features
 --------
 
-- Twitter Bootstrap 3 and Fontawesome 4 with starter templates
+- Bootstrap 3 and Font Awesome 4 with starter templates
 - Flask-SQLAlchemy with basic User model
 - Easy database migrations with Flask-Migrate
 - Flask-WTForms with login and registration forms

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/home.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/public/home.html
@@ -6,7 +6,7 @@
 {% endraw %}
   <h1>Welcome to {{ cookiecutter.project_name }}</h1>
 {% raw %}
-  <p>This is a starter Flask template. It includes Twitter Bootstrap 3, jQuery 2, Flask-SQLAlchemy, WTForms, and various testing utilities out of the box.</p>
+  <p>This is a starter Flask template. It includes Bootstrap 3, jQuery 2, Flask-SQLAlchemy, WTForms, and various testing utilities out of the box.</p>
   <p><a href="https://github.com/sloria/cookiecutter-flask" class="btn btn-primary btn-large">Learn more &raquo;</a></p>
 </div><!-- /.jumbotron -->
 


### PR DESCRIPTION
Bootstrap is no longer formally organizationally associated with Twitter, so it should be referred to simply as "Bootstrap" rather than "Twitter Bootstrap"; see https://github.com/twbs/bootstrap/blob/4120aadd68ddd15d2b8f0cddc9c72118caec9923/docs/about.html#L36

Also fixes the spelling of Font Awesome (two words, not one).
