### PR TITLE
Login form on nav.html posts to current page instead of "/"

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
@@ -34,7 +34,7 @@
     <ul class="nav navbar-nav navbar-right">
       <li><a href="{{ url_for('public.register') }}">Create account</a></li>
     </ul>
-    <form id="loginForm" method="POST" class="navbar-form form-inline navbar-right" action="" role="login">
+    <form id="loginForm" method="POST" class="navbar-form form-inline navbar-right" action="/" role="login">
       {{ form.hidden_tag() }}
       <div class="form-group">
         {{ form.username(placeholder="Username", class_="form-control") }}


### PR DESCRIPTION
Used to post to the current page, breaks if you're on the about page or others. Now correctly posts to "/".
