### PR TITLE
Hardcoding Flask-Script pip install to use 0.6.6 as the newer versions a...

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/dev.txt
+++ b/{{cookiecutter.app_name}}/requirements/dev.txt
@@ -6,7 +6,7 @@ pytest
 factory-boy>=2.2.1
 
 # Management script
-Flask-Script
+Flask-Script==0.6.6
 
 # Debug toolbar
 Flask-DebugToolbar==0.9.0


### PR DESCRIPTION
By default Flask-Script was set to install the latest version.
Flask-Script==2.0.3 is what got installed and wouldn't allow me to see stack traces in the browser and auto reload on file changes also didn't function.
