### PR TITLE
Use explicit relative import instead of implicit.

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/__init__.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/public/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 '''The public module, including the homepage and user auth.'''
 
-import views
+from . import views

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/__init__.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/__init__.py
@@ -1,3 +1,3 @@
 '''The user module.'''
 
-import views
+from . import views


### PR DESCRIPTION
Implicit relative imports are discouraged
( http://legacy.python.org/dev/peps/pep-0008/#imports ) and no longer supported
in python 3.
