### PR TITLE
Remove pinned python version from pipfile

### DIFF
--- a/{{cookiecutter.app_name}}/Pipfile
+++ b/{{cookiecutter.app_name}}/Pipfile
@@ -62,5 +62,3 @@ flake8-quotes = "==2.0.1"
 isort = "==4.3.20"
 pep8-naming = "==0.8.2"
 
-[requires]
-python_version = "{{cookiecutter.python_version}}"


### PR DESCRIPTION
Resolves https://github.com/cookiecutter-flask/cookiecutter-flask/issues/490. The introduction of the pinned python version resulted in Dependabot being unable to parse the Pipfile.

Tested by running Dependabot on my fork; the bot successfully parsed the Pipfile after this change.