### PR TITLE
Use binary version of psycopg

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -10,7 +10,7 @@ click>=5.0
 
 # Database
 Flask-SQLAlchemy==2.3.2
-psycopg2==2.8.2
+psycopg2-binary==2.8.2
 SQLAlchemy==1.2.11
 
 # Migrations


### PR DESCRIPTION
Beginning with the 2.8 release of `psycopg` (introduced into this project by PR https://github.com/cookiecutter-flask/cookiecutter-flask/pull/488), the `psycopg` package is built from source, requiring the user to install system dependencies. Switch to using psycopg-binary package to maintain pre-2.8 behavior of installing from wheel. There is [discussion](http://initd.org/psycopg/articles/2018/02/08/psycopg-274-released/) on the tradeoffs between `psycopg2` and `psycopg2-binary`; I'm defaulting to the binary version to decrease barrier to entry for new users of this project.