### PR TITLE
Allow cookiecutter build in docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,21 @@
 # Config file for automatic testing at travis-ci.org
+dist: xenial
 language: python
 python:
-  - 2.7
   - 3.5
   - 3.6
+  - 3.7
+
+env:
+  - INSTALL_NODE_VERSION=8
+  - INSTALL_NODE_VERSION=10
+  - INSTALL_NODE_VERSION=12
+
 install:
   - pip install cookiecutter
-  - pip install invoke==1.0.0
-  - nvm install 8.11.2
-  - nvm use 8.11.2
+  - pip install invoke==1.2.0
+  - nvm install $INSTALL_NODE_VERSION
+  - nvm use $INSTALL_NODE_VERSION
+
 script:
   - invoke test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7-alpine
+
+RUN apk update \
+    && apk upgrade \
+    && apk add --no-cache git
+
+RUN pip install \
+    cookiecutter==1.6.0
+
+ENTRYPOINT [ "python", "-m", "cookiecutter" ]

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,26 @@ A Flask template for cookiecutter_.
 
 Use it now
 ----------
-::
+
+Docker
+******
+
+.. code-block:: bash
+
+   $ ./cookiecutter-docker.sh --help
+        Usage: ./cookiecutter-docker.sh [OPTIONS]
+
+        Options:
+        -b, --build    Build Docker image before running cookiecutter
+        -t, --template Specify custom cookiecutter template via a URI to a git repo
+                       e.g. https://github.com/cookiecutter-flask/cookiecutter-flask.git
+                       Defaults to template in current working directory
+        -h, --help     Show this message and exit
+
+Standard
+********
+
+.. code-block:: bash
 
     $ pip install cookiecutter
     $ cookiecutter https://github.com/cookiecutter-flask/cookiecutter-flask.git
@@ -120,7 +139,7 @@ Changelog
 
 - Update stale requirements.
 - Add CSRF protection.
-- Run ``lint`` commmand on Travis builds.
+- Run ``lint`` command on Travis builds.
 - Test against Python 3.5.
 
 0.8.0 (11/09/2015)

--- a/cookiecutter-docker.sh
+++ b/cookiecutter-docker.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -e
+
+PROGNAME=$0
+BUILD_IMAGE=false
+COOKIECUTTER_TEMPLATE='.'
+
+
+usage() {
+  cat << EOF >&2
+Usage: $PROGNAME [OPTIONS]
+
+Options:
+-b, --build    Build Docker image before running cookiecutter
+-t, --template Specify custom cookiecutter template via a URI to a git repo
+               e.g. https://github.com/cookiecutter-flask/cookiecutter-flask.git
+               Defaults to template in current working directory
+-h, --help     Show this message and exit
+
+EOF
+    exit 1
+    }
+
+
+process_args() {
+    while test $# -gt 0
+    do
+      case "$1" in
+          -h) usage
+              ;;
+          --help) usage
+              ;;
+          -b) BUILD_IMAGE=true
+              ;;
+          --build) BUILD_IMAGE=true
+              ;;
+          -t) COOKIECUTTER_TEMPLATE="$2"
+              shift
+              ;;
+          --template) COOKIECUTTER_TEMPLATE="$2"
+              shift
+              ;;
+          --*) usage;
+              exit 1;
+              ;;
+          *) usage;
+              exit 1;
+              ;;
+      esac
+      shift
+  done
+}
+
+
+run_cookiecutter() {
+    if [[ "$(docker images -q cookiecutter-docker 2> /dev/null)" == "" ]] || $BUILD_IMAGE ; then
+    docker build . --tag=cookiecutter-docker
+    fi
+
+    docker run -i -t -v ${PWD}:/build -w /build cookiecutter-docker ${COOKIECUTTER_TEMPLATE}
+}
+
+process_args "$@"
+run_cookiecutter
+
+exit 0

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,5 +7,5 @@
 	"project_short_description": "A flasky app.",
 	"use_pipenv": ["no", "yes"],
 	"python_version": ["3.7", "3.6", "3.5"],
-	"node_version": ["12", "11", "10", "8"]
+	"node_version": ["12", "10", "8"]
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """Post gen hook to ensure that the generated project
-hase only one package managment, either pipenv or pip."""
+has only one package management, either pipenv or pip."""
 import os
 import shutil
 import sys
 
 
-def clean_extra_package_managment_files():
-    """Removes either requirements files and folderor the Pipfile."""
+def clean_extra_package_management_files():
+    """Removes either requirements files and folder or the Pipfile."""
     use_pipenv = '{{cookiecutter.use_pipenv}}'
     to_delete = []
 
@@ -32,4 +32,4 @@ def clean_extra_package_managment_files():
 
 
 if __name__ == '__main__':
-    clean_extra_package_managment_files()
+    clean_extra_package_management_files()

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,0 +1,33 @@
+import re
+import sys
+
+
+MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
+
+
+class bcolors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+
+def validate_python_module_name():
+    module_name = "{{ cookiecutter.app_name }}"
+    if not re.match(MODULE_REGEX, module_name):
+        print(
+            (
+                "\n{0}ERROR:{1} "
+                + "{2}{3}{1} is not a valid Python module name!\n"
+                + "See https://www.python.org/dev/peps/pep-0008/#package-and-module-names for naming standards.\n"
+            ).format(bcolors.WARNING, bcolors.ENDC, bcolors.BOLD, module_name)
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    validate_python_module_name()

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -6,14 +6,9 @@ MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
 
 class bcolors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKGREEN = "\033[92m"
     WARNING = "\033[93m"
-    FAIL = "\033[91m"
     ENDC = "\033[0m"
     BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
 
 
 def validate_python_module_name():


### PR DESCRIPTION
Builds the cookiecutter project entirely in docker via

```bash
$ ./cookiecutter-docker.sh
```

Expands the Travis CI test matrix to ensure all supported combinations of Python and Node are tested. In a future PR, may investigate leveraging docker-compose to run the Travis test suite for consistency with the process for launching the app in docker.