### PR TITLE
Implement temporary fix for breaking change in pydocstyle

### DIFF
--- a/{{cookiecutter.app_name}}/Pipfile
+++ b/{{cookiecutter.app_name}}/Pipfile
@@ -54,6 +54,7 @@ flake8 = "==3.7.7"
 flake8-blind-except = "==0.1.1"
 flake8-debugger = "==3.1.0"
 flake8-docstrings = "==1.3.0"
+pydocstyle = "<4" #temporary until flake8-docstrings is fixed
 flake8-isort = "==2.7.0"
 isort = "==4.3.21"
 pep8-naming = "==0.8.2"

--- a/{{cookiecutter.app_name}}/requirements/dev.txt
+++ b/{{cookiecutter.app_name}}/requirements/dev.txt
@@ -13,6 +13,7 @@ flake8==3.7.7
 flake8-blind-except==0.1.1
 flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
+pydocstyle<4 #temporary until flake8-docstrings is fixed
 flake8-isort==2.5
 isort==4.3.4
 pep8-naming==0.7.0


### PR DESCRIPTION
This project uses `flake8-docstrings`, which contained an unpinned dependency on `pydocstyle`. A breaking change in `pydocstyle` is causing our CI pipelines to fail erroneously. This PR pins `pydocstyle`; this change will be reverted once a fix is pushed to `flake8-docstrings`.