### PR TITLE
Fix flask test command

### DIFF
--- a/{{cookiecutter.app_name}}/tests/conftest.py
+++ b/{{cookiecutter.app_name}}/tests/conftest.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Defines fixtures available to all tests."""
 
+import logging
+
 import pytest
 from webtest import TestApp
 
@@ -14,6 +16,7 @@ from .factories import UserFactory
 def app():
     """Create application for the tests."""
     _app = create_app("tests.settings")
+    _app.logger.setLevel(logging.CRITICAL)
     ctx = _app.test_request_context()
     ctx.push()
 


### PR DESCRIPTION
Fix for issue mentioned in https://github.com/cookiecutter-flask/cookiecutter-flask/issues/546.
It is caused by app logger.

Same fix was introduced in googleapis/oauth2client: [Silence flask app logger during tests](https://github.com/googleapis/oauth2client/pull/566/files)