### PR TITLE
Fix missing environmental variables in travis.yml

### DIFF
--- a/{{cookiecutter.app_name}}/.travis.yml
+++ b/{{cookiecutter.app_name}}/.travis.yml
@@ -2,7 +2,7 @@
 dist: xenial
 language: python
 env:
-- FLASK_APP=autoapp.py FLASK_DEBUG=1
+- FLASK_APP=autoapp.py FLASK_DEBUG=1 DATABASE_URL=sqlite:////test.db SECRET_KEY=test-secret
 python:
   - 3.6
   - 3.7

--- a/{{cookiecutter.app_name}}/.travis.yml
+++ b/{{cookiecutter.app_name}}/.travis.yml
@@ -1,8 +1,6 @@
 # Config file for automatic testing at travis-ci.org
 dist: xenial
 language: python
-env:
-- FLASK_APP=autoapp.py FLASK_DEBUG=1 DATABASE_URL=sqlite:////test.db SECRET_KEY=test-secret
 python:
   - 3.6
   - 3.7
@@ -12,6 +10,7 @@ install:
   - nvm use {{cookiecutter.node_version}}
   - npm install
 before_script:
+  - cp .env.example .env
   - npm run lint
   - npm run build
   - flask lint --check


### PR DESCRIPTION
I've add `DATABASE_URL` and `SECRET_KEY` because I received errors on Travis (due to missing environmental variables in `settings.py`)