### PR TITLE
Update deprecated database field

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -39,7 +39,7 @@ class User(UserMixin, SurrogatePK, Model):
     username = Column(db.String(80), unique=True, nullable=False)
     email = Column(db.String(80), unique=True, nullable=False)
     #: The hashed password
-    password = Column(db.Binary(128), nullable=True)
+    password = Column(db.LargeBinary(128), nullable=True)
     created_at = Column(db.DateTime, nullable=False, default=dt.datetime.utcnow)
     first_name = Column(db.String(30), nullable=True)
     last_name = Column(db.String(30), nullable=True)


### PR DESCRIPTION
 The deprecated `Binary` class is used in `User` model. I've run tests on CI with `LargeBinary` instead of `Binary` class used and there was no warning. I've checked it on my hobby project that password is stored properly.

Source code of the warning: https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/sql/sqltypes.py#L986.
