### PR TITLE
Remove pinned pydocstyle version

### DIFF
--- a/{{cookiecutter.app_name}}/Pipfile
+++ b/{{cookiecutter.app_name}}/Pipfile
@@ -54,7 +54,6 @@ flake8 = "==3.7.8"
 flake8-blind-except = "==0.1.1"
 flake8-debugger = "==3.1.0"
 flake8-docstrings = "==1.4.0"
-pydocstyle = "<4" #temporary until flake8-docstrings is fixed
 flake8-isort = "==2.7.0"
 isort = "==4.3.21"
 pep8-naming = "==0.8.2"

--- a/{{cookiecutter.app_name}}/requirements/dev.txt
+++ b/{{cookiecutter.app_name}}/requirements/dev.txt
@@ -13,7 +13,6 @@ flake8==3.7.8
 flake8-blind-except==0.1.1
 flake8-debugger==3.1.0
 flake8-docstrings==1.4.0
-pydocstyle<4 #temporary until flake8-docstrings is fixed
 flake8-isort==2.7.0
 isort==4.3.21
 pep8-naming==0.8.2


### PR DESCRIPTION
Previous versions of `flake8-docstrings` had an unpinned dependency on `pydocstyle`, causing compatibility issues. The most recent version of `flake8-docstrings` pinned the dependency, and as such we no longer need to manually pin `pydocstyle`.