### PR TITLE
Remove jinja templating from requirements

### DIFF
--- a/{{cookiecutter.app_name}}/Pipfile
+++ b/{{cookiecutter.app_name}}/Pipfile
@@ -12,9 +12,7 @@ click = ">=5.0"
 # Database
 Flask-SQLAlchemy = "==2.4.1"
 SQLAlchemy = "==1.3.9"
-{%- if cookiecutter.use_heroku == "yes" %}
 psycopg2-binary = "==2.8.3"
-{%- endif %}
 
 # Migrations
 Flask-Migrate = "==2.5.2"

--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -8,9 +8,7 @@ click>=7.0
 # Database
 Flask-SQLAlchemy==2.4.1
 SQLAlchemy==1.3.9
-{%- if cookiecutter.use_heroku == "yes" %}
 psycopg2-binary==2.8.3
-{%- endif %}
 
 # Migrations
 Flask-Migrate==2.5.2


### PR DESCRIPTION
Dependabot fails when it encounters a jinja template. Given that there's only one package that's conditionally being installed, let's just add it for everyone.