### PR TITLE
Adds pipenv shell to docs

### DIFF
--- a/{{cookiecutter.app_name}}/README.rst
+++ b/{{cookiecutter.app_name}}/README.rst
@@ -14,6 +14,7 @@ Run the following commands to bootstrap your environment ::
     cd {{cookiecutter.app_name}}
     {%- if cookiecutter.use_pipenv == "yes" %}
     pipenv install --dev
+    pipenv shell
     {%- else %}
     pip install -r requirements/dev.txt
     {%- endif %}


### PR DESCRIPTION
It might be confusing for beginners following the docs if the `pipenv shell` is not there (that is, in case pinenv is being used)

