### PR TITLE
Warn when running Cookiecutter with incompatible python version

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -2,37 +2,42 @@ import logging
 import re
 import sys
 
-LOGGER = logging.getLogger()
+# Provide ability to import from the `hooks` directory
+sys.path.append("..")
+
+logging.basicConfig()
+LOGGER = logging.getLogger(__name__)
 MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
 
-class bcolors:
-    WARNING = "\033[93m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-
-
-def colorize(escape_code, text):
-    code = getattr(bcolors, escape_code)
-    return f"{code}{text}{bcolors.ENDC}"
-
-
-def log_warning(module_name):
+def check_python_version():
+    python_major_version = sys.version_info[0]
+    python_minor_version = sys.version_info[1]
+    # Must remain compatible with Python 2 to provide useful error message.
     warning = (
-        f"\n{colorize('WARNING', 'WARNING:')} {colorize('BOLD', module_name)}"
-        " is not a valid Python module name!\n"
-        "See https://www.python.org/dev/peps/pep-0008/#package-and-module-names"
-        " for naming standards.\n"
-    )
-    LOGGER.warning(warning)
+        "\nWARNING: You are running cookiecutter using "
+        "Python {}.{}, but a version >= Python 3.6+ is required.\n"
+        "Either install a more recent version of Python, or use the Docker instructions.\n"
+    ).format(python_major_version, python_minor_version)
+    if (python_major_version == 2) or (
+        python_major_version == 3 and python_minor_version < 6
+    ):
+        LOGGER.warning(warning)
+        sys.exit(1)
 
 
 def validate_python_module_name():
     module_name = "{{ cookiecutter.app_name }}"
     if not re.match(MODULE_REGEX, module_name):
-        log_warning(module_name)
+        log_module_name_warning(module_name, LOGGER)
         sys.exit(1)
 
 
 if __name__ == "__main__":
+    check_python_version()
+
+    # Import after validating Python version to prevent confusing SyntaxError
+    # for users with incompatible Python versions.
+    from hooks.utils import log_module_name_warning
+
     validate_python_module_name()

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -1,0 +1,19 @@
+class bcolors:
+    WARNING = "\033[93m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+
+
+def colorize(escape_code, text):
+    code = getattr(bcolors, escape_code)
+    return f"{code}{text}{bcolors.ENDC}"
+
+
+def log_module_name_warning(module_name, logger):
+    warning = (
+        f"\n{colorize('WARNING', 'WARNING:')} {colorize('BOLD', module_name)}"
+        " is not a valid Python module name!\n"
+        "See https://www.python.org/dev/peps/pep-0008/#package-and-module-names"
+        " for naming standards.\n"
+    )
+    logger.warning(warning)


### PR DESCRIPTION
There have been two recent issues raised by users who generate a project with an incompatible version of Python: (#616 and #642).

The README contains information about the supported versions of Python, but trying to execute the cookiecutter with an incompatible version raises a SyntaxError, rather than a warning about the Python version.

Therefore, this adds an addition check to the `pre_gen_project` hook to prompt users to use a more recent version of Python.