### PR TITLE
Move SEND_FILE_MAX_AGE_DEFAULT comment to line above

### DIFF
--- a/{{cookiecutter.app_name}}/.env.example
+++ b/{{cookiecutter.app_name}}/.env.example
@@ -6,4 +6,5 @@ DATABASE_URL=sqlite:////tmp/dev.db
 GUNICORN_WORKERS=1
 LOG_LEVEL=debug
 SECRET_KEY=not-so-secret
-SEND_FILE_MAX_AGE_DEFAULT=0 # In production, set to a higher number, like 31556926
+# In production, set to a higher number, like 31556926
+SEND_FILE_MAX_AGE_DEFAULT=0


### PR DESCRIPTION
This prevents the environs library from failing to parse the .env file, fixing bug #660 