### PR TITLE
Override system environment variables when using Pipenv

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
@@ -9,11 +9,7 @@ environment variables.
 from environs import Env
 
 env = Env()
-{% if cookiecutter.use_pipenv %}
-env.read_env(override=True)
-{% else %}
-env.read_env()
-{% endif %}
+{% if cookiecutter.use_pipenv == "yes" %}env.read_env(override=True){% elif cookiecutter.use_pipenv == "no" %}env.read_env(){% endif %}
 
 ENV = env.str("FLASK_ENV", default="production")
 DEBUG = ENV == "development"

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
@@ -9,7 +9,11 @@ environment variables.
 from environs import Env
 
 env = Env()
+{% if cookiecutter.use_pipenv %}
+env.read_env(override=True)
+{% else %}
 env.read_env()
+{% endif %}
 
 ENV = env.str("FLASK_ENV", default="production")
 DEBUG = ENV == "development"


### PR DESCRIPTION
This prevents https://github.com/cookiecutter-flask/cookiecutter-flask/issues/660 from occurring by forcing environs to override existing system variables.