### PR TITLE
Prevent "Cannot find module 'babel-preset-env'"

### DIFF
--- a/{{cookiecutter.app_name}}/webpack.config.js
+++ b/{{cookiecutter.app_name}}/webpack.config.js
@@ -76,7 +76,7 @@ module.exports = {
         test: /\.(ttf|eot|svg|png|jpe?g|gif|ico)(\?.*)?$/i,
         loader: `file-loader?context=${rootAssetPath}&name=[path][name].[ext]`
       },
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', query: { presets: ['env'], cacheDirectory: true } },
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', query: { presets: ["@babel/preset-env"], cacheDirectory: true } },
     ],
   }
 };


### PR DESCRIPTION
This commit prevents the error: "Error: Cannot find module 'babel-preset-env'".
For details see https://github.com/cookiecutter-flask/cookiecutter-flask/issues/666