### PR TITLE
Update Pipfile fix pipenv error

### DIFF
--- a/{{cookiecutter.app_name}}/Pipfile
+++ b/{{cookiecutter.app_name}}/Pipfile
@@ -43,6 +43,9 @@ Flask-DebugToolbar = "==0.10.1"
 environs = "==7.1.0"
 
 [dev-packages]
+setuptools_scm = "==3.3.3"
+pytest-runner = "==5.2"
+
 # Testing
 pytest = "==5.3.2"
 WebTest = "==2.0.33"


### PR DESCRIPTION
An error occurred while installing fancycompleter==0.8 --hash=sha256:d2522f1f3512371f295379c4c0d1962de06762eb586c199620a2a5d423539b12 --hash=sha256:d2522f1f3512371f295379c4c0d1962de06762eb586c199620a2a5d423539b12! Will try again.
An error occurred while installing flake8-debugger==3.2.1 --hash=sha256:712d7c1ff69ddf3f0130e94cc88c2519e720760bce45e8c330bfdcb61ab4090d! Will try again.
An error occurred while installing pdbpp==0.10.2 --hash=sha256:73ff220d5006e0ecdc3e2705d8328d8aa5ac27fef95cc06f6e42cd7d22d55eb8! Will try again.

> now it will be install successful