### PR TITLE
Update heroku docs

### DIFF
--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -218,6 +218,7 @@ Deployment by using [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cl
     ```bash
     heroku config:set SECRET_KEY=not-so-secret
     heroku config:set FLASK_APP=autoapp.py
+    heroku config:set SEND_FILE_MAX_AGE_DEFAULT=31556926
     ```
 
 * Please check `.env.example` to see which environmental variables are used in the project and also need to be set. The exception is `DATABASE_URL`, which Heroku sets automatically.


### PR DESCRIPTION
In a clean setup, and following all the instructions, leads to an error of missing `SEND_FILE_MAX_AGE_DEFAULT`. 
I added a line in the readme setting that variable to the example found in `.env.example`

Looking at the issues, and it seems some people had the same issue:
https://github.com/cookiecutter-flask/cookiecutter-flask/issues/790#issuecomment-643551198