### PR TITLE
Migrate SurrogatePK to abstract class

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/database.py
@@ -41,14 +41,10 @@ class Model(CRUDMixin, db.Model):
 
     __abstract__ = True
 
+class PkModel(Model):
+    """Base model class that includes CRUD convenience methods, plus adds a 'primary key' column named ``id``"""
 
-# From Mike Bayer's "Building the app" talk
-# https://speakerdeck.com/zzzeek/building-the-app
-class SurrogatePK(object):
-    """A mixin that adds a surrogate integer 'primary key' column named ``id`` to any declarative-mapped class."""
-
-    __table_args__ = {"extend_existing": True}
-
+    __abstract__ = True
     id = Column(db.Integer, primary_key=True)
 
     @classmethod
@@ -62,7 +58,6 @@ class SurrogatePK(object):
         ):
             return cls.query.get(int(record_id))
         return None
-
 
 def reference_col(
     tablename, nullable=False, pk_name="id", foreign_key_kwargs=None, column_kwargs=None

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -24,7 +24,7 @@ class Role(PkModel):
 
     def __init__(self, name, **kwargs):
         """Create instance."""
-        db.Model.__init__(self, name=name, **kwargs)
+        super().__init__(name=name, **kwargs)
 
     def __repr__(self):
         """Represent instance as a unique string."""
@@ -47,7 +47,7 @@ class User(UserMixin, PkModel):
 
     def __init__(self, username, email, password=None, **kwargs):
         """Create instance."""
-        super().__init__(self, username=username, email=email, **kwargs)
+        super().__init__(username=username, email=email, **kwargs)
         if password:
             self.set_password(password)
         else:

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -47,7 +47,7 @@ class User(UserMixin, PkModel):
 
     def __init__(self, username, email, password=None, **kwargs):
         """Create instance."""
-        db.Model.__init__(self, username=username, email=email, **kwargs)
+        super().__init__(self, username=username, email=email, **kwargs)
         if password:
             self.set_password(password)
         else:

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/user/models.py
@@ -6,8 +6,7 @@ from flask_login import UserMixin
 
 from {{cookiecutter.app_name}}.database import (
     Column,
-    Model,
-    SurrogatePK,
+    PkModel,
     db,
     reference_col,
     relationship,
@@ -15,7 +14,7 @@ from {{cookiecutter.app_name}}.database import (
 from {{cookiecutter.app_name}}.extensions import bcrypt
 
 
-class Role(SurrogatePK, Model):
+class Role(PkModel):
     """A role for a user."""
 
     __tablename__ = "roles"
@@ -32,7 +31,7 @@ class Role(SurrogatePK, Model):
         return f"<Role({self.name})>"
 
 
-class User(UserMixin, SurrogatePK, Model):
+class User(UserMixin, PkModel):
     """A user of the app."""
 
     __tablename__ = "users"


### PR DESCRIPTION
`__table_args__ = {"extend_existing": True}` breaks a lot of scenarios for inheritance, which are relatively common. This seems to have happened after SQLAlchemy 2.3.2 according to #230

Removing table_args, and we get `Table 'association' is already defined for this MetaData instance.  Specify 'extend_existing=True' to redefine options and columns on an existing Table object.`

This might not be the nicest way to fix the problem because it uses inheritance, but I could not find any better way without fiddling with SQLAlchemy internals. This might even be a case to escalate this to SQLAlchemy as a bug (ie, incompatibility of Mixins and Inheritance)

Another alternative is to have the Primary key directly in `Model` but that might be way too intrusive since a lot of people like to have control over their PK

Fixes issue #230