### PR TITLE
Fix GitHub actions with pipenv

### DIFF
--- a/{{cookiecutter.app_name}}/.github/workflows/lint.yaml
+++ b/{{cookiecutter.app_name}}/.github/workflows/lint.yaml
@@ -31,6 +31,14 @@ jobs:
       - name: Run Node lints
         run: npm run lint
       - name: Run Python lints
+        {%- if cookiecutter.use_pipenv == "yes" %}
+        run: pipenv run flask lint --check
+        {%- else %}
         run: flask lint --check
+        {%- endif %}
       - name: Run Python tests
+        {%- if cookiecutter.use_pipenv == "yes" %}
+        run: pipenv run flask test
+        {%- else %}
         run: flask test
+        {%- endif %}

--- a/{{cookiecutter.app_name}}/.github/workflows/lint.yaml
+++ b/{{cookiecutter.app_name}}/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           {%- if cookiecutter.use_pipenv == "yes" %}
           pip install pipenv
-          RUN pipenv install --dev
+          pipenv install --dev
           {%- else %}
           python -m pip install --upgrade pip
           pip install -r requirements/dev.txt


### PR DESCRIPTION
When I used this cookiecutter yesterday I kept getting errors in GitHub actions. I was using the use_pipenv option.

I found that the following changes needed to be made to the lint.yaml file.

I tested out the changes with a new blank app test and pushed it to GitHub and the GitHub actions worked (https://github.com/nstoik/test_app)