### PR TITLE
Add lint for committed example code

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,7 @@ name: Build Status
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:
@@ -30,3 +31,5 @@ jobs:
         run: invoke test
       - name: Run lints
         run: invoke lint
+      - name: Make sure placeholders not being committed
+        run: invoke no-placeholders

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
-  "full_name": "Steven Loria",
-  "email": "sloria1@gmail.com",
-  "github_username": "sloria",
+  "full_name": "First Last",
+  "email": "example@gmail.com",
+  "github_username": "yourGithubUsername",
   "project_name": "My Flask App",
   "app_name": "{{cookiecutter.project_name.lower().replace('-', '_').replace(' ', '_')}}",
   "project_short_description": "A flasky app.",

--- a/tasks.py
+++ b/tasks.py
@@ -2,6 +2,7 @@
 import json
 import os
 import shutil
+from typing import Iterator
 
 from invoke import task
 
@@ -9,7 +10,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(HERE, "cookiecutter.json"), "r") as fp:
     COOKIECUTTER_SETTINGS = json.load(fp)
 # Match default value of app_name from cookiecutter.json
-COOKIECUTTER_SETTINGS["app_name"] = "my_flask_app"
+DEFAULT_APP_NAME = "my_flask_app"
+COOKIECUTTER_SETTINGS["app_name"] = DEFAULT_APP_NAME
 COOKIE = os.path.join(HERE, COOKIECUTTER_SETTINGS["app_name"])
 REQUIREMENTS = os.path.join(COOKIE, "requirements", "dev.txt")
 
@@ -65,3 +67,24 @@ def test(ctx):
     os.environ["FLASK_ENV"] = "production"
     os.environ["FLASK_DEBUG"] = "0"
     _run_flask_command(ctx, "test")
+
+
+def _walk_template_files() -> Iterator[str]:
+    template_dir = os.path.join(HERE, "{{cookiecutter.app_name}}")
+    for root, _, template_files in os.walk(template_dir):
+        for template_file in template_files:
+            yield os.path.join(root, template_file)
+
+
+@task
+def no_placeholders(ctx):
+    """Check that default project name hasn't been committed to template dir"""
+    for template_file in _walk_template_files():
+        try:
+            with open(template_file, "r") as f:
+                if DEFAULT_APP_NAME in f.read():
+                    raise ValueError(
+                        f"Template cannot contain default app name, but {DEFAULT_APP_NAME} found in {f.name}"
+                    )
+        except UnicodeDecodeError:
+            pass


### PR DESCRIPTION
There have been a few regressions from snippets of demo code (like `my_flask_app`) that were accidentally committed instead of the template value. This PR adds a lint that prevents this.