### PR TITLE
Fix webpack breaking changes

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,3 +33,5 @@ jobs:
         run: invoke lint
       - name: Make sure placeholders not being committed
         run: invoke no-placeholders
+      - name: Make sure Docker images can build
+        run: invoke test-image-build

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ MIT licensed.
 - Remove support for Node 10 as a Cookiecutter option
 - Refactored Docker image to use multistage builds more efficiently
 - Projects generated with the template use Github actions for CI
+- Upgrade Webpack to 5.x
 
 ### 18.0.0 (09/09/2018)
 

--- a/tasks.py
+++ b/tasks.py
@@ -88,3 +88,11 @@ def no_placeholders(ctx):
                     )
         except UnicodeDecodeError:
             pass
+
+
+@task(pre=[clean, build])
+def test_image_build(ctx):
+    """Run tests."""
+    os.chdir(COOKIE)
+    os.environ["DOCKER_BUILDKIT"] = "1"
+    ctx.run("docker-compose build flask-dev", echo=True)

--- a/{{cookiecutter.app_name}}/Dockerfile
+++ b/{{cookiecutter.app_name}}/Dockerfile
@@ -9,6 +9,8 @@ WORKDIR /app
 
 COPY --from=node /usr/local/bin/ /usr/local/bin/
 COPY --from=node /usr/lib/ /usr/lib/
+# See https://github.com/moby/moby/issues/37965
+RUN true
 COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 {%- if cookiecutter.use_pipenv == "yes" %}

--- a/{{cookiecutter.app_name}}/package.json
+++ b/{{cookiecutter.app_name}}/package.json
@@ -4,8 +4,8 @@
   "description": "{{cookiecutter.project_short_description}}",
   "scripts": {
     "build": "run-script-os",
-    "build:win32": "SET NODE_ENV=production && webpack --progress --colors -p && npm run flask-static-digest",
-    "build:default": "NODE_ENV=production webpack --progress --colors -p && npm run flask-static-digest",
+    "build:win32": "SET NODE_ENV=production && webpack --progress --color --optimization-minimize && npm run flask-static-digest",
+    "build:default": "NODE_ENV=production webpack --progress --color --optimization-minimize && npm run flask-static-digest",
     "start": "run-script-os",
     "start:win32": "concurrently -n \"WEBPACK,FLASK\" -c \"bgBlue.bold,bgMagenta.bold\" \"npm run webpack-watch:win32\" \"npm run flask-server\"",
     "start:default": "concurrently -n \"WEBPACK,FLASK\" -c \"bgBlue.bold,bgMagenta.bold\" \"npm run webpack-watch\" \"npm run flask-server\"",
@@ -42,7 +42,7 @@
     "babel-loader": "^8.1.0",
     "chokidar": "^3.4.2",
     "concurrently": "^5.3.0",
-    "css-loader": "^4.3.0",
+    "css-loader": "^5.0.1",
     "eslint": "^7.10.0",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.1",
@@ -53,7 +53,7 @@
     "raw-loader": "^4.0.1",
     "run-script-os": "^1.1.1",
     "url-loader": "^4.1.0",
-    "webpack": "^4.44.2",
-    "webpack-cli": "^4.0.0"
+    "webpack": "^5.5.1",
+    "webpack-cli": "^4.2.0"
   }
 }

--- a/{{cookiecutter.app_name}}/webpack.config.js
+++ b/{{cookiecutter.app_name}}/webpack.config.js
@@ -52,7 +52,6 @@ module.exports = {
           {
             loader: MiniCssExtractPlugin.loader,
             options: {
-              hmr: debug,
             },
           },
           'css-loader!less-loader',
@@ -64,7 +63,6 @@ module.exports = {
           {
             loader: MiniCssExtractPlugin.loader,
             options: {
-              hmr: debug,
             },
           },
           'css-loader',
@@ -74,9 +72,10 @@ module.exports = {
       { test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader', options: { limit: 10000, mimetype: 'application/font-woff' } },
       {
         test: /\.(ttf|eot|svg|png|jpe?g|gif|ico)(\?.*)?$/i,
-        loader: `file-loader?context=${rootAssetPath}&name=[path][name].[ext]`
+        loader: 'file-loader',
+        options: { context: '${rootAssetPath}&name=[path][name].[ext]' }
       },
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', query: { presets: ["@babel/preset-env"], cacheDirectory: true } },
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader', options: { presets: ["@babel/preset-env"], cacheDirectory: true } },
     ],
   }
 };


### PR DESCRIPTION
Fixes issues introduced by upgrading Webpack to 5.x. Additionally, it updates the CI pipeline to add a step that builds the Docker image associated with the generated project, which would have caught this issue. 

Closes https://github.com/cookiecutter-flask/cookiecutter-flask/issues/954
Closes https://github.com/cookiecutter-flask/cookiecutter-flask/issues/955