### PR TITLE
Update README.md to  heroku main instead of master

### DIFF
--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -226,7 +226,7 @@ Deployment by using [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cl
 * Deploy on Heroku by pushing to the `heroku` branch
 
     ```bash
-    git push heroku master
+    git push heroku main
     ```
 
 {%- endif %}


### PR DESCRIPTION
With GitHub changes, it makes sense to switch `master` to `main`.