### PR TITLE
fix entry point for 'manage' container

### DIFF
--- a/{{cookiecutter.app_name}}/docker-compose.yml
+++ b/{{cookiecutter.app_name}}/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       target: development
       args:
         <<: *build_args
-    entrypoint: pipenv run flask
+    entrypoint: {% if cookiecutter.use_pipenv == 'True' %}pipenv run {% endif %}flask
     environment:
       FLASK_ENV: production
       FLASK_DEBUG: 0

--- a/{{cookiecutter.app_name}}/docker-compose.yml
+++ b/{{cookiecutter.app_name}}/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       target: development
       args:
         <<: *build_args
-    entrypoint: flask
+    entrypoint: pipenv run flask
     environment:
       FLASK_ENV: production
       FLASK_DEBUG: 0


### PR DESCRIPTION
Before commands such as `docker-compose run --rm manage test` failed with an error message:

    Error response from daemon: OCI runtime create failed: container_linux.go:349: starting container process caused "exec: \"flask\": executable file not found in $PATH": unknown