### PR TITLE
Bugfix: Use free sign out FA icon

### DIFF
--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/templates/nav.html
@@ -26,7 +26,7 @@
       </li>
       <li class="nav-item">
         <a class="nav-link" href="{{ url_for('public.logout') }}">
-          <i class="fa fa-sign-out"></i>
+          <i class="fa fa-sign-out-alt"></i>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
Thanks for this project! I was having an issue where the Font-Awesome sign-out icon wasn't showing up for me. I looked at the icon list and it appears that `fa-sign-out` is a PRO icon, whereas `fa-sign-out-alt` is free. This PR changes the icon to use the free version so it shows up once cookie-cut.
