### PR TITLE
fixes assets/js/main.js require() to conform with AirBnB standard

### DIFF
--- a/{{cookiecutter.app_name}}/assets/js/main.js
+++ b/{{cookiecutter.app_name}}/assets/js/main.js
@@ -17,5 +17,5 @@ require.context(
 );
 
 // Your own code
-require('./plugins.js');
-require('./script.js');
+require('./plugins');
+require('./script');


### PR DESCRIPTION
New projects fail `Run Node lints` step out of box because `assets/js/main.js` does not conform to the AirBnB standard

https://github.com/airbnb/javascript#modules