### PR TITLE
Renaming default value for CACHE_TYPE

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -31,7 +31,7 @@ Flask-Bcrypt==1.0.1
 Flask-Login==0.6.2
 
 # Caching
-Flask-Caching>=1.7.2
+Flask-Caching>=2.0.2
 
 # Debug toolbar
 Flask-DebugToolbar==0.13.1

--- a/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
+++ b/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}/settings.py
@@ -19,5 +19,5 @@ SEND_FILE_MAX_AGE_DEFAULT = env.int("SEND_FILE_MAX_AGE_DEFAULT")
 BCRYPT_LOG_ROUNDS = env.int("BCRYPT_LOG_ROUNDS", default=13)
 DEBUG_TB_ENABLED = DEBUG
 DEBUG_TB_INTERCEPT_REDIRECTS = False
-CACHE_TYPE = "simple"  # Can be "memcached", "redis", etc.
+CACHE_TYPE = "SimpleCache"  # Can be "MemcachedCache", "RedisCache", etc.
 SQLALCHEMY_TRACK_MODIFICATIONS = False


### PR DESCRIPTION
Flask-Caching renamed its built-in cache types and the default configuration should reflect this.

https://flask-caching.readthedocs.io/en/latest/#configuring-flask-caching
