### PR TITLE
Revert "Bump werkzeug from 2.3.0 to 2.3.2 in /{{cookiecutter.app_name}}/requirements"

### DIFF
--- a/{{cookiecutter.app_name}}/requirements/prod.txt
+++ b/{{cookiecutter.app_name}}/requirements/prod.txt
@@ -3,7 +3,7 @@
 # Flask
 click>=7.0
 Flask==2.2.3
-Werkzeug==2.3.2
+Werkzeug==2.3.0
 
 # Database
 Flask-SQLAlchemy==3.0.3


### PR DESCRIPTION
Reverts cookiecutter-flask/cookiecutter-flask#1725