### PR TITLE
Update to currently supported node LTS versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.md
@@ -17,10 +17,10 @@ Additionally, please complete the following section with the options you used to
 
 Project configuration:
 
-| Option                               | Values                                                                                     |
-| ------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `use_pipenv`                         | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                           |
+| Option                               | Values                                                                                      |
+| ------------------------------------ | ------------------------------------------------------------------------------------------- |
+| `use_pipenv`                         | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                            |
 | `python_version`                     | <ul><li>- [ ] `3.11`</li><li>- [ ] `3.10`</li><li>- [ ] `3.9`</li><li>- [ ] `3.8`</li></ul> |
-| `node_version`                       | <ul><li>- [ ] `18`</li><li>- [ ] `16`</li><li>- [ ] `14`</li></ul>                         |
-| `use_heroku`                         | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                           |
-| Are you using Docker to run the app? | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                           |
+| `node_version`                       | <ul><li>- [ ] `20`</li><li>- [ ] `18`</li></ul>                                             |
+| `use_heroku`                         | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                            |
+| Are you using Docker to run the app? | <ul><li>- [ ] `yes`</li><li>- [ ] `no`</li></ul>                                            |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ MIT licensed.
 - Upgrade Webpack to 5.x
 - Dropped Python 3.6 and 3.7 support
 - Added Python 3.9, 3.10, and 3.11 support
-- Added Node 16 and 18 LTS
-- Removed Node 12 LTS
+- Added Node 18 and 20 LTS
+- Removed Node 12, 14, and 16 LTS
 
 ### 18.0.0 (09/09/2018)
 

--- a/cookiecutter_spec.py
+++ b/cookiecutter_spec.py
@@ -84,8 +84,8 @@ interactions: List[columbo.Interaction] = [
     columbo.Choice(
         "node_version",
         "Which version of Node will this application use?",
-        options=["18", "16", "14"],
-        default="18",
+        options=["20", "18"],
+        default="20",
     ),
     columbo.Confirm(
         "use_heroku",


### PR DESCRIPTION
Removes support for the Node 16 LTS, which is coming up on the end of support (should not be used for new projects), and was causing some issues in #1435