### PR TITLE
fix shell command in README.md

### DIFF
--- a/{{cookiecutter.app_name}}/README.md
+++ b/{{cookiecutter.app_name}}/README.md
@@ -100,7 +100,7 @@ flask run       # start the flask server
 To open the interactive shell, run
 
 ```bash
-docker-compose run --rm manage db shell
+docker-compose run --rm manage shell
 flask shell # If running locally without Docker
 ```
 


### PR DESCRIPTION
**Currently:**
`docker-compose run --rm manage db shell`
results in:
```
Error: No such command 'shell'.
```
**Suggested:**
`docker-compose run --rm manage shell`
results in:
```
Creating foobar_manage_run ... done
Loading .env environment variables...
Python 3.11.4 (main, Jun 13 2023, 15:34:37) [GCC 8.3.0] on linux
App: foobar
Instance: /app/instance
>>>
```